### PR TITLE
Return localtime-based results

### DIFF
--- a/ext/strptime/strptime.c
+++ b/ext/strptime/strptime.c
@@ -402,6 +402,7 @@ strptime_init(VALUE self, VALUE fmt)
 {
     struct strptime_object *tobj;
     void **isns;
+    StringValue(fmt);
     TypedData_Get_Struct(self, struct strptime_object, &strptime_data_type, tobj);
     isns = strptime_compile(RSTRING_PTR(fmt), RSTRING_LEN(fmt));
     tobj->isns = isns;
@@ -452,6 +453,7 @@ strptime_exec(VALUE self, VALUE str)
     struct strptime_object *tobj;
     time_t t;
     int r, nsec=0, gmtoff=0;
+    StringValue(str);
     GetStrptimeval(self, tobj);
 
     r = strptime_exec0(tobj->isns, RSTRING_PTR(tobj->fmt),
@@ -478,6 +480,7 @@ strptime_execi(VALUE self, VALUE str)
     struct strptime_object *tobj;
     time_t t;
     int r, subsec=0, gmtoff=0;
+    StringValue(str);
     GetStrptimeval(self, tobj);
 
     r = strptime_exec0(tobj->isns, RSTRING_PTR(tobj->fmt),

--- a/spec/strptime_spec.rb
+++ b/spec/strptime_spec.rb
@@ -96,15 +96,77 @@ describe Strptime do
 
   it 'parses %Y%m%d%H%M%S' do
     pr = Strptime.new("%Y%m%d%H%M%S")
-    expect(pr.exec("20150610102415").to_i).to eq(1433931855)
-    expect(pr.exec("20150610102415").utc_offset).to eq(0)
-    expect(pr.exec("20150610102415").utc_offset).to eq(0)
+    expect(pr.exec("20150610102415").utc_offset).to eq(Time.now.utc_offset)
   end
 
   it 'parses %Y-%m-%d %H:%M:%S' do
     pr = Strptime.new("%Y-%m-%d %H:%M:%S")
-    expect(pr.exec("2015-06-10 10:24:15").to_i).to eq(1433931855)
-    expect(pr.exec("2015-06-10 10:24:15").utc_offset).to eq(0)
-    expect(pr.exec("2015-06-10 10:24:15").utc_offset).to eq(0)
+    expect(pr.exec("2015-06-11 10:24:15").year).to eq(2015)
+    expect(pr.exec("2015-06-11 10:24:15").month).to eq(6)
+    expect(pr.exec("2015-06-11 10:24:15").day).to eq(11)
+    expect(pr.exec("2015-06-11 10:24:15").hour).to eq(10)
+    expect(pr.exec("2015-06-11 10:24:15").min).to eq(24)
+    expect(pr.exec("2015-06-11 10:24:15").sec).to eq(15)
+    expect(pr.exec("2015-06-11 10:24:15").nsec).to eq(0)
+    expect(pr.exec("2015-06-11 10:24:15").utc_offset).to eq(Time.now.utc_offset)
+  end
+
+  it 'parses %d' do
+    pr = Strptime.new("%d")
+    expect(pr.exec("10").year).to eq(Time.now.year)
+    expect(pr.exec("10").month).to eq(Time.now.month)
+    expect(pr.exec("10").day).to eq(10)
+    expect(pr.exec("10").hour).to eq(0)
+    expect(pr.exec("10").min).to eq(0)
+    expect(pr.exec("10").sec).to eq(0)
+    expect(pr.exec("10").nsec).to eq(0)
+    expect(pr.exec("10").utc_offset).to eq(Time.now.utc_offset)
+  end
+
+  it 'parses %S%z' do
+    pr = Strptime.new("%S%z")
+    expect(pr.exec("12-03:00").year).to eq(Time.now.localtime("-03:00").year)
+    expect(pr.exec("12-03:00").month).to eq(Time.now.localtime("-03:00").month)
+    expect(pr.exec("12-03:00").day).to eq(Time.now.localtime("-03:00").day)
+    expect(pr.exec("12-03:00").hour).to eq(Time.now.localtime("-03:00").hour)
+    expect(pr.exec("12-03:00").min).to eq(Time.now.localtime("-03:00").min)
+    expect(pr.exec("12-03:00").sec).to eq(12)
+    expect(pr.exec("12-03:00").nsec).to eq(0)
+    expect(pr.exec("12-03:00").utc_offset).to eq(-3*3600)
+
+    expect(pr.exec("12+09:00").year).to eq(Time.now.localtime("+09:00").year)
+    expect(pr.exec("12+09:00").month).to eq(Time.now.localtime("+09:00").month)
+    expect(pr.exec("12+09:00").day).to eq(Time.now.localtime("+09:00").day)
+    expect(pr.exec("12+09:00").hour).to eq(Time.now.localtime("+09:00").hour)
+    expect(pr.exec("12+09:00").min).to eq(Time.now.localtime("+09:00").min)
+    expect(pr.exec("12+09:00").sec).to eq(12)
+    expect(pr.exec("12+09:00").nsec).to eq(0)
+    expect(pr.exec("12+09:00").utc_offset).to eq(9*3600)
+
+    expect(pr.exec("12+11:00").year).to eq(Time.now.localtime("+11:00").year)
+    expect(pr.exec("12+11:00").month).to eq(Time.now.localtime("+11:00").month)
+    expect(pr.exec("12+11:00").day).to eq(Time.now.localtime("+11:00").day)
+    expect(pr.exec("12+11:00").hour).to eq(Time.now.localtime("+11:00").hour)
+    expect(pr.exec("12+11:00").min).to eq(Time.now.localtime("+11:00").min)
+    expect(pr.exec("12+11:00").sec).to eq(12)
+    expect(pr.exec("12+11:00").nsec).to eq(0)
+    expect(pr.exec("12+11:00").utc_offset).to eq(11*3600)
+  end
+
+  ## from test/test_time.rb
+  it 'parses empty format' do
+    expect{Strptime.new("").exec("")}.to raise_error(ArgumentError)
+    expect{Strptime.new("%z").exec("+09:00")}.to raise_error(ArgumentError)
+  end
+
+  it 'parses %Y%d%m %z' do
+    pr = Strptime.new('%Y%m%d %z')
+    expect(pr.exec('20010203 -0200').year).to eq(2001)
+    expect(pr.exec('20010203 -0200').mon).to eq(2)
+    expect(pr.exec('20010203 -0200').day).to eq(3)
+    expect(pr.exec('20010203 -0200').hour).to eq(0)
+    expect(pr.exec('20010203 -0200').min).to eq(0)
+    expect(pr.exec('20010203 -0200').sec).to eq(0)
+    expect(pr.exec('20010203 -0200').utc_offset).to eq(-7200)
   end
 end


### PR DESCRIPTION
Closes #3
- This behaviour is based on `Time.strptime` but not `DateTime.strptime`.
- Return cached results of gmtime(3)/localtime(3) only when given time_t is equal with cached time_t.
